### PR TITLE
Design Cloudflare Pages deployment for examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ out
 # Nuxt.js build / generate output
 .nuxt
 dist
+dist-examples
 
 # Gatsby files
 .cache/

--- a/docs/cloudflare-pages-deployment.md
+++ b/docs/cloudflare-pages-deployment.md
@@ -1,0 +1,136 @@
+# Cloudflare Pages Deployment Guide
+
+This guide explains how to deploy the Realtime Audio SDK examples to Cloudflare Pages.
+
+## Prerequisites
+
+- A Cloudflare account
+- A GitHub repository with this project
+
+## Deployment Methods
+
+### Method 1: Connect to Git (Recommended)
+
+1. Go to [Cloudflare Pages](https://pages.cloudflare.com/)
+2. Click "Create a project" > "Connect to Git"
+3. Select your repository
+4. Configure the build settings:
+
+| Setting | Value |
+|---------|-------|
+| Framework preset | None |
+| Build command | `npm run build:examples` |
+| Build output directory | `dist-examples` |
+| Root directory | `/` (leave empty) |
+
+5. Set environment variables (if needed):
+   - `NODE_VERSION`: `18` (or higher)
+
+6. Click "Save and Deploy"
+
+### Method 2: Direct Upload
+
+```bash
+# Build locally
+npm install
+npm run build:examples
+
+# Upload dist-examples folder via Cloudflare Dashboard
+```
+
+### Method 3: Wrangler CLI
+
+1. Install Wrangler:
+```bash
+npm install -g wrangler
+```
+
+2. Login to Cloudflare:
+```bash
+wrangler login
+```
+
+3. Deploy:
+```bash
+npm run build:examples
+wrangler pages deploy dist-examples --project-name=realtime-audio-sdk
+```
+
+## Build Output Structure
+
+```
+dist-examples/
+├── index.html              # Examples navigation page
+├── basic/
+│   └── index.html          # Basic example
+├── vad/
+│   └── index.html          # VAD demo
+├── transcription/
+│   └── index.html          # Transcription example
+├── assets/
+│   └── *.js                # Bundled JavaScript
+├── models/
+│   └── silero_vad_v5.onnx  # VAD model (downloaded during build)
+├── ort-wasm-simd.wasm      # ONNX Runtime WASM files
+├── ort-wasm-simd-threaded.wasm
+└── ort-wasm.wasm
+```
+
+## Configuration Files
+
+### wrangler.toml (Optional)
+
+```toml
+name = "realtime-audio-sdk-examples"
+compatibility_date = "2024-01-01"
+
+[site]
+bucket = "./dist-examples"
+```
+
+## CORS and Headers
+
+For WASM files and SharedArrayBuffer support, you may need custom headers.
+Create `_headers` file in `examples/public/`:
+
+```
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+```
+
+## Troubleshooting
+
+### VAD Model Not Found
+
+If the VAD model fails to download during build:
+
+1. Check the build logs for download errors
+2. Manually download the model:
+   ```bash
+   curl -L -o examples/public/models/silero_vad_v5.onnx \
+     https://media.githubusercontent.com/media/snakers4/silero-vad/master/src/silero_vad/data/silero_vad_v5.onnx
+   ```
+3. Commit the model file to your repository
+
+### WASM Loading Errors
+
+Ensure the WASM files are being served with correct MIME type (`application/wasm`).
+Cloudflare Pages handles this automatically.
+
+### Microphone Access
+
+- HTTPS is required for `getUserMedia`
+- Cloudflare Pages provides HTTPS by default
+
+## Custom Domain
+
+1. Go to your project in Cloudflare Pages Dashboard
+2. Click "Custom domains"
+3. Add your domain
+4. Update DNS records as instructed
+
+## Environment Variables
+
+No environment variables are required for the examples.
+All configuration is done at runtime in the browser.

--- a/examples/basic/index.html
+++ b/examples/basic/index.html
@@ -129,7 +129,7 @@
   <div class="logs" id="logs"></div>
 
   <script type="module">
-    import { RTA } from '../../src/index.ts';
+    import { RTA } from '@/index.ts';
 
     let sdk = null;
     let chunkCount = 0;

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Realtime Audio SDK - Examples</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      min-height: 100vh;
+    }
+
+    .container {
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 40px 20px;
+    }
+
+    header {
+      text-align: center;
+      color: white;
+      margin-bottom: 40px;
+    }
+
+    header h1 {
+      font-size: 2.5rem;
+      margin: 0 0 10px 0;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+
+    header p {
+      font-size: 1.1rem;
+      opacity: 0.9;
+      margin: 0;
+    }
+
+    .examples-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+      gap: 24px;
+    }
+
+    .example-card {
+      background: white;
+      border-radius: 16px;
+      padding: 28px;
+      box-shadow: 0 10px 40px rgba(0,0,0,0.15);
+      transition: transform 0.2s, box-shadow 0.2s;
+      text-decoration: none;
+      color: inherit;
+      display: block;
+    }
+
+    .example-card:hover {
+      transform: translateY(-4px);
+      box-shadow: 0 15px 50px rgba(0,0,0,0.2);
+    }
+
+    .card-icon {
+      font-size: 3rem;
+      margin-bottom: 16px;
+    }
+
+    .card-title {
+      font-size: 1.4rem;
+      font-weight: 600;
+      margin: 0 0 10px 0;
+      color: #1a1a2e;
+    }
+
+    .card-description {
+      color: #666;
+      font-size: 0.95rem;
+      line-height: 1.5;
+      margin: 0 0 16px 0;
+    }
+
+    .card-features {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .feature-tag {
+      background: #f0f4ff;
+      color: #4f46e5;
+      padding: 4px 10px;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      font-weight: 500;
+    }
+
+    .footer {
+      text-align: center;
+      margin-top: 40px;
+      color: white;
+      opacity: 0.8;
+    }
+
+    .footer a {
+      color: white;
+    }
+
+    .badge {
+      display: inline-block;
+      background: rgba(255,255,255,0.2);
+      color: white;
+      padding: 6px 14px;
+      border-radius: 20px;
+      font-size: 0.85rem;
+      margin-top: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Realtime Audio SDK</h1>
+      <p>Audio capture, VAD, and real-time encoding for the Web</p>
+      <span class="badge">v0.1.0</span>
+    </header>
+
+    <div class="examples-grid">
+      <a href="./basic/" class="example-card">
+        <div class="card-icon">🎙️</div>
+        <h2 class="card-title">Basic Example</h2>
+        <p class="card-description">
+          Get started with audio capture, device selection, and real-time encoding.
+          Monitor audio energy levels and speech detection.
+        </p>
+        <div class="card-features">
+          <span class="feature-tag">Audio Capture</span>
+          <span class="feature-tag">Device Selection</span>
+          <span class="feature-tag">Opus Encoding</span>
+          <span class="feature-tag">VAD</span>
+        </div>
+      </a>
+
+      <a href="./vad/" class="example-card">
+        <div class="card-icon">🗣️</div>
+        <h2 class="card-title">VAD Demo</h2>
+        <p class="card-description">
+          Voice Activity Detection with Silero VAD v5. Capture speech segments
+          with configurable thresholds and real-time visualization.
+        </p>
+        <div class="card-features">
+          <span class="feature-tag">Silero VAD v5</span>
+          <span class="feature-tag">Speech Segments</span>
+          <span class="feature-tag">Waveform View</span>
+          <span class="feature-tag">Playback</span>
+        </div>
+      </a>
+
+      <a href="./transcription/" class="example-card">
+        <div class="card-icon">📝</div>
+        <h2 class="card-title">Transcription</h2>
+        <p class="card-description">
+          Real-time speech-to-text integration example. Demonstrates how to
+          connect the SDK to a transcription service via WebSocket.
+        </p>
+        <div class="card-features">
+          <span class="feature-tag">WebSocket</span>
+          <span class="feature-tag">Speech-to-Text</span>
+          <span class="feature-tag">Real-time</span>
+        </div>
+      </a>
+    </div>
+
+    <div class="footer">
+      <p>
+        <a href="https://github.com/realtime-ai/realtime-audio-sdk" target="_blank">GitHub</a>
+        &nbsp;&bull;&nbsp;
+        <a href="https://github.com/realtime-ai/realtime-audio-sdk#readme" target="_blank">Documentation</a>
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/public/_headers
+++ b/examples/public/_headers
@@ -1,0 +1,9 @@
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+
+/*.wasm
+  Content-Type: application/wasm
+
+/*.onnx
+  Content-Type: application/octet-stream

--- a/examples/public/models/README.md
+++ b/examples/public/models/README.md
@@ -1,15 +1,35 @@
 # VAD Models
 
-This directory should contain the Silero VAD v5 ONNX model.
+This directory should contain the Silero VAD v5 ONNX model for Voice Activity Detection.
 
-## Download
+## Automatic Download
 
-Download the model file from:
-https://github.com/snakers4/silero-vad/blob/master/src/silero_vad/data/silero_vad_v5.onnx
+The model is automatically downloaded during build:
 
-Save it as: `silero_vad_v5.onnx`
-
-Or use this direct link:
 ```bash
-curl -L -o silero_vad_v5.onnx https://github.com/snakers4/silero-vad/raw/master/src/silero_vad/data/silero_vad_v5.onnx
+npm run download:model
 ```
+
+Or as part of the full examples build:
+
+```bash
+npm run build:examples
+```
+
+## Manual Download
+
+If automatic download fails, you can manually download the model:
+
+**Option 1: GitHub LFS**
+```bash
+curl -L -o silero_vad_v5.onnx https://media.githubusercontent.com/media/snakers4/silero-vad/master/src/silero_vad/data/silero_vad_v5.onnx
+```
+
+**Option 2: Direct from Repository**
+1. Visit: https://github.com/snakers4/silero-vad/blob/master/src/silero_vad/data/silero_vad_v5.onnx
+2. Click "Download" or "Raw" button
+3. Save as `silero_vad_v5.onnx` in this directory
+
+## File Size
+
+The model file should be approximately 2MB. If your downloaded file is much smaller, the download may have failed.

--- a/examples/transcription/index.html
+++ b/examples/transcription/index.html
@@ -71,7 +71,7 @@
   </div>
 
   <script type="module">
-    import { RTA } from '../../src/index.ts';
+    import { RTA } from '@/index.ts';
 
     let sdk = null;
     let ws = null;
@@ -100,7 +100,7 @@
           silenceDuration: 800,           // Shorter silence duration (800ms)
           preSpeechPadDuration: 300,
           minSpeechDuration: 100,         // Lower min duration to catch short utterances
-          modelPath: '/public/models/silero_vad_v5.onnx',
+          modelPath: '/models/silero_vad_v5.onnx',
         },
       },
     });

--- a/examples/vad/index.html
+++ b/examples/vad/index.html
@@ -524,7 +524,7 @@
   </div>
 
   <script type="module">
-    import { RTA } from '../../src/index.ts';
+    import { RTA } from '@/index.ts';
 
     let sdk = null;
     let segments = [];
@@ -574,7 +574,7 @@
         silenceDuration: parseInt(silenceDuration.value),
         preSpeechPadDuration: 300,
         minSpeechDuration: parseInt(minSpeechDuration.value),
-        modelPath: '/public/models/silero_vad_v5.onnx',
+        modelPath: '/models/silero_vad_v5.onnx',
       };
     }
 

--- a/package.json
+++ b/package.json
@@ -19,9 +19,12 @@
   "scripts": {
     "prepare": "husky",
     "copy:wasm": "mkdir -p examples/public && cp node_modules/onnxruntime-web/dist/*.wasm node_modules/onnxruntime-web/dist/*.mjs examples/public/ 2>/dev/null || true",
+    "download:model": "mkdir -p examples/public/models && (test -f examples/public/models/silero_vad_v5.onnx || curl -fsSL -o examples/public/models/silero_vad_v5.onnx https://media.githubusercontent.com/media/snakers4/silero-vad/master/src/silero_vad/data/silero_vad_v5.onnx || echo 'Warning: Could not download VAD model')",
     "dev": "npm run copy:wasm && vite",
     "build": "tsc && vite build",
+    "build:examples": "npm run copy:wasm && npm run download:model && vite build --config vite.examples.config.ts",
     "preview": "vite preview",
+    "preview:examples": "vite preview --config vite.examples.config.ts",
     "type-check": "tsc --noEmit",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",

--- a/vite.examples.config.ts
+++ b/vite.examples.config.ts
@@ -1,0 +1,82 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import { copyFileSync, mkdirSync, existsSync, readdirSync } from 'fs';
+
+export default defineConfig({
+  root: './examples',
+  base: '/',
+  build: {
+    outDir: '../dist-examples',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'examples/index.html'),
+        basic: resolve(__dirname, 'examples/basic/index.html'),
+        vad: resolve(__dirname, 'examples/vad/index.html'),
+        transcription: resolve(__dirname, 'examples/transcription/index.html'),
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
+  optimizeDeps: {
+    exclude: ['onnxruntime-web'],
+  },
+  assetsInclude: ['**/*.wasm', '**/*.onnx'],
+  plugins: [
+    {
+      name: 'copy-wasm-assets',
+      closeBundle() {
+        const distDir = './dist-examples';
+
+        // Copy ONNX models
+        const modelsDir = `${distDir}/models`;
+        if (!existsSync(modelsDir)) {
+          mkdirSync(modelsDir, { recursive: true });
+        }
+
+        const sourceModelsDir = './examples/public/models';
+        if (existsSync(sourceModelsDir)) {
+          const files = readdirSync(sourceModelsDir);
+          let onnxFound = false;
+          files.forEach(file => {
+            if (file.endsWith('.onnx')) {
+              const srcPath = `${sourceModelsDir}/${file}`;
+              const destPath = `${modelsDir}/${file}`;
+              copyFileSync(srcPath, destPath);
+              console.log(`Copied: ${file} -> ${destPath}`);
+              onnxFound = true;
+            }
+          });
+          if (!onnxFound) {
+            console.warn('Warning: No ONNX model files found. VAD features may not work.');
+            console.warn('Run: npm run download:model to download the Silero VAD model.');
+          }
+        }
+
+        // Copy WASM files from onnxruntime-web
+        const wasmFiles = [
+          'ort-wasm-simd-threaded.wasm',
+          'ort-wasm-simd.wasm',
+          'ort-wasm.wasm',
+          'ort-wasm-simd-threaded.mjs',
+          'ort-wasm-simd.mjs',
+        ];
+
+        const onnxDist = './node_modules/onnxruntime-web/dist';
+        if (existsSync(onnxDist)) {
+          wasmFiles.forEach(file => {
+            const src = `${onnxDist}/${file}`;
+            if (existsSync(src)) {
+              copyFileSync(src, `${distDir}/${file}`);
+              console.log(`Copied: ${file}`);
+            }
+          });
+        }
+      }
+    }
+  ],
+});


### PR DESCRIPTION
- Add vite.examples.config.ts for building examples as static site
- Create examples/index.html navigation page
- Update import paths to use @ alias for SDK
- Fix model paths (remove /public prefix)
- Add build:examples and preview:examples scripts
- Add download:model script for VAD model
- Add _headers file for CORS and WASM support
- Add deployment documentation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Vite config and scripts to build the examples as a static site to `dist-examples`, introduces an examples index page, fixes SDK import/model paths, sets required headers, and documents Cloudflare Pages deployment.
> 
> - **Build/Tooling**:
>   - Add `vite.examples.config.ts` to build examples to `dist-examples` with multi-page inputs and asset copying (ONNX `.onnx` and ORT `.wasm/.mjs`).
>   - New NPM scripts: `build:examples`, `preview:examples`, `download:model`; enhance `.gitignore` with `dist-examples`.
> - **Examples**:
>   - New `examples/index.html` landing page linking to `basic`, `vad`, and `transcription` demos.
>   - Update example imports to `@/index.ts` and fix VAD `modelPath` to `/models/silero_vad_v5.onnx`.
> - **Static Assets/CORS**:
>   - Add `examples/public/_headers` for COOP/COEP and MIME types for `.wasm`/`.onnx`.
> - **Docs**:
>   - Add `docs/cloudflare-pages-deployment.md` detailing build settings and deployment methods for Cloudflare Pages.
>   - Expand `examples/public/models/README.md` with auto/manual model download instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63bf29d65fae839f3a3bae7c48d2d0d02369fab3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->